### PR TITLE
Add Nfc HAL module ID for NXP NCI PN54x chips

### DIFF
--- a/include/hardware/nfc.h
+++ b/include/hardware/nfc.h
@@ -54,6 +54,7 @@ __BEGIN_DECLS
  */
 #define NFC_NCI_HARDWARE_MODULE_ID "nfc_nci"
 #define NFC_NCI_BCM2079X_HARDWARE_MODULE_ID "nfc_nci.bcm2079x"
+#define NFC_NCI_NXP_PN54X_HARDWARE_MODULE_ID "nfc_nci.pn54x"
 #define NFC_NCI_CONTROLLER "nci"
 
 /*


### PR DESCRIPTION
Conflicts:
    include/hardware/nfc.h

Change-Id: Ic6980daa9512b5594e1db966cff7042f2503586e
