### PR TITLE
Bug 1171862 - fix the mismatched HWC_BLIT value between hal and gecko…

### DIFF
--- a/include/hardware/hwcomposer_defs.h
+++ b/include/hardware/hwcomposer_defs.h
@@ -125,7 +125,7 @@ enum {
     HWC_CURSOR_OVERLAY =  5,
 
     /* this layer will be handled in the HWC, using a blit engine */
-    HWC_BLIT = 6,
+    HWC_BLIT = 0xFF,
 };
 /*
  * hwc_layer_t::blending values


### PR DESCRIPTION
… for flame-l.
